### PR TITLE
0.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ioris/core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ioris/core",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ioris/core",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Line.test.ts
+++ b/src/Line.test.ts
@@ -79,19 +79,22 @@ describe("Line", () => {
     });
 
     it("should return the updated line", () => {
-      const beforeJointNearWordID = jointNearWordLine.wordByPosition.get(1)?.id;
+      const beforeJointNearWordID1 =
+        jointNearWordLine.wordByPosition.get(1)?.id || "";
+      const beforeJointNearWordID2 =
+        jointNearWordLine.wordByPosition.get(2)?.id || "";
 
       const updatedJointNearWordLine = jointNearWordLine.update({
         position: 1,
         timelines: [
           {
-            wordID: jointNearWordLine.wordByPosition.get(1)?.id,
+            wordID: beforeJointNearWordID1,
             begin: 0.3,
             end: 0.5,
             text: "開か",
           },
           {
-            wordID: jointNearWordLine.wordByPosition.get(2)?.id,
+            wordID: beforeJointNearWordID2,
             begin: 0.65,
             end: 1,
             text: "ない",
@@ -102,12 +105,12 @@ describe("Line", () => {
       });
 
       expect(updatedJointNearWordLine.wordByPosition.get(1)?.id).toStrictEqual(
-        beforeJointNearWordID,
+        beforeJointNearWordID1,
       );
       expect(
         updatedJointNearWordLine.wordByPosition.get(1)?.timeline,
       ).toStrictEqual({
-        wordID: beforeJointNearWordID,
+        wordID: beforeJointNearWordID1,
         begin: 0.3,
         end: 1,
         text: "開かない",
@@ -115,20 +118,22 @@ describe("Line", () => {
         hasWhitespace: false,
       });
 
-      const beforeNotJointNearWordID =
-        notJointNearWordLine.wordByPosition.get(1)?.id;
+      const beforeNotJointNearWordID1 =
+        notJointNearWordLine.wordByPosition.get(1)?.id || "";
+      const beforeNotJointNearWordID2 =
+        notJointNearWordLine.wordByPosition.get(2)?.id || "";
 
       const updatedNotJointNearWordLine = notJointNearWordLine.update({
         position: 1,
         timelines: [
           {
-            wordID: notJointNearWordLine.wordByPosition.get(1)?.id,
+            wordID: beforeNotJointNearWordID1,
             begin: 0.3,
             end: 0.5,
             text: "開か",
           },
           {
-            wordID: notJointNearWordLine.wordByPosition.get(2)?.id,
+            wordID: beforeNotJointNearWordID2,
             begin: 0.65,
             end: 1,
             text: "ない",
@@ -139,11 +144,11 @@ describe("Line", () => {
       });
       expect(
         updatedNotJointNearWordLine.wordByPosition.get(1)?.id,
-      ).toStrictEqual(beforeNotJointNearWordID);
+      ).toStrictEqual(beforeNotJointNearWordID1);
       expect(
         updatedNotJointNearWordLine.wordByPosition.get(1)?.timeline,
       ).toStrictEqual({
-        wordID: beforeNotJointNearWordID,
+        wordID: beforeNotJointNearWordID1,
         begin: 0.3,
         end: 0.5,
         text: "開か",

--- a/src/Paragraph.test.ts
+++ b/src/Paragraph.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Paragraph } from "./Paragraph";
+import {
+  Paragraph,
+  type ParagraphCreateArgs,
+  type ParagraphUpdateArgs,
+  isParagraphCreateArgs,
+} from "./Paragraph";
 
 describe("Paragraph", () => {
   let paragraph: Paragraph;
@@ -312,6 +317,34 @@ describe("Paragraph", () => {
     });
     it("not void", () => {
       expect(paragraph.isVoid(1.4)).toBe(false);
+    });
+
+    describe("isParagraphCreateArgs", () => {
+      it("should return true when object has lyricID", () => {
+        const createArgs: ParagraphCreateArgs = {
+          lyricID: "test-id",
+          position: 1,
+          timelines: [],
+        };
+        expect(isParagraphCreateArgs(createArgs)).toBe(true);
+      });
+
+      it("should return false when object does not have lyricID", () => {
+        const updateArgs: ParagraphUpdateArgs = {
+          position: 1,
+          timelines: [],
+        };
+        expect(isParagraphCreateArgs(updateArgs)).toBe(false);
+      });
+
+      it("should return true when lyricID is an empty string", () => {
+        const createArgs = {
+          lyricID: "",
+          position: 1,
+          timelines: [],
+        };
+        expect(isParagraphCreateArgs(createArgs)).toBe(true);
+      });
     });
   });
 });

--- a/src/Paragraph.ts
+++ b/src/Paragraph.ts
@@ -18,6 +18,12 @@ export type ParagraphUpdateArgs = {
   ) => Promise<Map<number, LineUpdateArgs>>;
 };
 
+export function isParagraphCreateArgs(
+  args: ParagraphCreateArgs | ParagraphUpdateArgs,
+): args is ParagraphCreateArgs {
+  return (args as ParagraphCreateArgs).lyricID !== undefined;
+}
+
 export class Paragraph {
   id: string;
   lyricID: string;
@@ -44,10 +50,18 @@ export class Paragraph {
         ? lastTimelines[lastTimelines.length - 1]
         : null;
       const thisFirst = timelines[0];
+      if (!thisFirst) {
+        console.error(
+          "thisFirst is undefined",
+          this._args.timelines,
+          timelines,
+        );
+        return acc;
+      }
       if (
         last &&
         (last.end > thisFirst.begin ||
-          (last.end === thisFirst.begin && last.text.length < 8))
+          (last.end === thisFirst.begin && last.text.length < 6))
       ) {
         last.end = thisFirst.end;
         last.text += ` ${thisFirst.text}`;

--- a/src/Word.test.ts
+++ b/src/Word.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { Word } from "./Word";
+import { Word, isWordCreateArgs, isWordTimeline } from "./Word";
 
 describe("Word", () => {
   let word: Word;
@@ -258,6 +258,42 @@ describe("Word", () => {
           equal: false,
         }),
       ).toBe(false);
+    });
+
+    describe("isWordCreateArgs", () => {
+      it("should return true when args has lineID", () => {
+        const args = {
+          lineID: "1",
+          position: 1,
+          timeline: {
+            begin: 0,
+            end: 1,
+            text: "test",
+          },
+        };
+        expect(isWordCreateArgs(args)).toBe(true);
+      });
+    });
+
+    describe("isWordTimeline", () => {
+      it("should return true when timeline has wordID", () => {
+        const timeline = {
+          wordID: "1",
+          begin: 0,
+          end: 1,
+          text: "test",
+        };
+        expect(isWordTimeline(timeline)).toBe(true);
+      });
+
+      it("should return false when timeline doesn't have wordID", () => {
+        const timeline = {
+          begin: 0,
+          end: 1,
+          text: "test",
+        };
+        expect(isWordTimeline(timeline)).toBe(false);
+      });
     });
   });
 });

--- a/src/Word.ts
+++ b/src/Word.ts
@@ -4,13 +4,25 @@ import { CHAR_TYPES, type WordTimeline } from "./Constants";
 export type WordCreateArgs = {
   lineID: string;
   position: number;
-  timeline: Omit<WordTimeline, "wordID">;
+  timeline: WordTimeline | Omit<WordTimeline, "wordID">;
 };
 
 export type WordUpdateArgs = {
   position: number;
   timeline: WordTimeline;
 };
+
+export function isWordCreateArgs(
+  args: WordCreateArgs | WordUpdateArgs,
+): args is WordCreateArgs {
+  return (args as WordCreateArgs).lineID !== undefined;
+}
+
+export function isWordTimeline(
+  args: WordTimeline | Omit<WordTimeline, "wordID">,
+): args is WordTimeline {
+  return (args as WordTimeline).wordID !== undefined;
+}
 
 export class Word {
   id: string;
@@ -33,7 +45,9 @@ export class Word {
   }
 
   private init(props: WordCreateArgs) {
-    this.id = `word-${crypto.randomUUID()}`;
+    this.id = isWordTimeline(props.timeline)
+      ? props.timeline.wordID
+      : `word-${crypto.randomUUID()}`;
     this.timeline = {
       ...props.timeline,
       hasNewLine: props.timeline.hasNewLine ?? false,


### PR DESCRIPTION
This pull request includes updates to the `package.json` version, enhancements to the test files for `Line`, `Paragraph`, and `Word` components, and the addition of type guards in the `Paragraph` and `Word` components. The most important changes include the following:

### Version Update:
* Updated the version in `package.json` from `0.1.19` to `0.1.20`.

### Test Enhancements:
* Improved `Line` component tests by introducing additional variables to handle word IDs and updating the assertions accordingly in `src/Line.test.ts`. [[1]](diffhunk://#diff-02b5d59a09c4f05c1c65ac6f8da7c11c8ea0531163d04077512e0bae02c3b430L82-R97) [[2]](diffhunk://#diff-02b5d59a09c4f05c1c65ac6f8da7c11c8ea0531163d04077512e0bae02c3b430L105-R136) [[3]](diffhunk://#diff-02b5d59a09c4f05c1c65ac6f8da7c11c8ea0531163d04077512e0bae02c3b430L142-R151)
* Added tests for `isParagraphCreateArgs` in the `Paragraph` component test file `src/Paragraph.test.ts`.
* Added tests for `isWordCreateArgs` and `isWordTimeline` in the `Word` component test file `src/Word.test.ts`.

### Type Guards:
* Added the `isParagraphCreateArgs` type guard function to `src/Paragraph.ts` to differentiate between `ParagraphCreateArgs` and `ParagraphUpdateArgs`.
* Added the `isWordCreateArgs` and `isWordTimeline` type guard functions to `src/Word.ts` to differentiate between `WordCreateArgs`, `WordUpdateArgs`, and `WordTimeline`. [[1]](diffhunk://#diff-a35de0a37499a836b75478e0b987fd629235060a75f6be8820c88f98ec9673e3L7-R26) [[2]](diffhunk://#diff-a35de0a37499a836b75478e0b987fd629235060a75f6be8820c88f98ec9673e3L36-R50)

### Error Handling:
* Added error handling in the `Paragraph` class to log an error and return early if `thisFirst` is undefined in `src/Paragraph.ts`.